### PR TITLE
45-friend-match

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -846,13 +846,17 @@ async function createMatch(p1: User, p2: User, mode: Mode, botDifficulty?: BotDi
   if (botDifficulty) botDifficulties.set(matchId, botDifficulty);
 
   const room = `match:${matchId}`;
-  io.sockets.sockets.get(sbUser.socketId)?.join(room);
-  io.sockets.sockets.get(bbUser.socketId)?.join(room);
+  for (const sid of io.sockets.adapter.rooms.get(`user:${sbUser.userId}`) ?? []) {
+    io.sockets.sockets.get(sid)?.join(room);
+  }
+  for (const sid of io.sockets.adapter.rooms.get(`user:${bbUser.userId}`) ?? []) {
+    io.sockets.sockets.get(sid)?.join(room);
+  }
 
-  io.sockets.sockets.get(sbUser.socketId)?.emit("match.found", {
+  io.to(`user:${sbUser.userId}`).emit("match.found", {
     matchId, opponent: { userId: bbUser.userId, username: bbUser.username }, mode,
   });
-  io.sockets.sockets.get(bbUser.socketId)?.emit("match.found", {
+  io.to(`user:${bbUser.userId}`).emit("match.found", {
     matchId, opponent: { userId: sbUser.userId, username: sbUser.username }, mode,
   });
 
@@ -937,6 +941,7 @@ io.on("connection", (socket: Socket) => {
         elo:      dbUser.elo,
       };
       users.set(socket.id, user);
+      socket.join(`user:${user.userId}`);
       console.log(`[auth] ${user.username} (${user.userId.slice(0, 8)}) elo=${user.elo}`);
       ack({ userId: user.userId, username: user.username, elo: user.elo });
 
@@ -1158,18 +1163,12 @@ io.on("connection", (socket: Socket) => {
       });
 
       // Also try instant socket delivery if target is connected
-      for (const [, u] of users) {
-        if (u.userId === toUserId) {
-          const targetSocket = io.sockets.sockets.get(u.socketId);
-          targetSocket?.emit("challenge.received", {
-            challengeId,
-            fromUsername: user.username,
-            fromUserId: user.userId,
-            mode,
-          });
-          break;
-        }
-      }
+      io.to(`user:${toUserId}`).emit("challenge.received", {
+        challengeId,
+        fromUsername: user.username,
+        fromUserId: user.userId,
+        mode,
+      });
 
       ack({ challengeId });
       console.log(`[challenge] ${user.username} → ${toUserId.slice(0, 8)} mode=${mode} id=${challengeId.slice(0, 8)}`);
@@ -1208,6 +1207,28 @@ io.on("connection", (socket: Socket) => {
   );
 
   socket.on(
+    "challenge.cancel",
+    ({ challengeId }: { challengeId: string }) => {
+      const user = users.get(socket.id);
+      if (!user) return;
+
+      const challenge = pendingChallenges.get(challengeId);
+      if (!challenge || challenge.fromUser.userId !== user.userId) return;
+
+      clearTimeout(challenge.timer);
+      pendingChallenges.delete(challengeId);
+      supabaseAdmin.from("pending_challenges").delete().eq("id", challengeId).then(({ error }) => {
+        if (error) console.error("[challenge] db delete (cancel) error:", error.message);
+      });
+
+      // Notify target that challenge was cancelled
+      io.to(`user:${challenge.toUserId}`).emit("challenge.expired", { challengeId });
+
+      console.log(`[challenge] cancelled ${challengeId.slice(0, 8)} by ${user.username}`);
+    },
+  );
+
+  socket.on(
     "challenge.decline",
     ({ challengeId }: { challengeId: string }) => {
       const user = users.get(socket.id);
@@ -1223,13 +1244,7 @@ io.on("connection", (socket: Socket) => {
       });
 
       // Notify challenger
-      for (const [, u] of users) {
-        if (u.userId === challenge.fromUser.userId) {
-          const challengerSocket = io.sockets.sockets.get(u.socketId);
-          challengerSocket?.emit("challenge.declined", { challengeId });
-          break;
-        }
-      }
+      io.to(`user:${challenge.fromUser.userId}`).emit("challenge.declined", { challengeId });
 
       console.log(`[challenge] declined ${challengeId.slice(0, 8)}`);
     },
@@ -1253,12 +1268,7 @@ io.on("connection", (socket: Socket) => {
             if (error) console.error("[challenge] db delete (disconnect) error:", error.message);
           });
           // Notify target
-          for (const [, u] of users) {
-            if (u.userId === challenge.toUserId) {
-              io.sockets.sockets.get(u.socketId)?.emit("challenge.expired", { challengeId: cid });
-              break;
-            }
-          }
+          io.to(`user:${challenge.toUserId}`).emit("challenge.expired", { challengeId: cid });
         }
       }
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -471,6 +471,7 @@ function FriendsCard({
   pendingChallenge,
   onAcceptChallenge,
   onDeclineChallenge,
+  onCancelChallenge,
   challengeWaiting,
 }: {
   friends:            Friend[];
@@ -479,7 +480,8 @@ function FriendsCard({
   pendingChallenge:   IncomingChallenge | null;
   onAcceptChallenge:  () => void;
   onDeclineChallenge: () => void;
-  challengeWaiting:   string | null; // friendId we're waiting on
+  onCancelChallenge:  () => void;
+  challengeWaiting:   { friendId: string; challengeId: string } | null;
 }) {
   const [showLink, setShowLink] = useState(false);
   const [copied, setCopied]     = useState(false);
@@ -612,7 +614,7 @@ function FriendsCard({
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem", maxHeight: 300, overflowY: "auto" }}>
           {friends.map((f) => {
-            const isWaiting = challengeWaiting === f.id;
+            const isWaiting = challengeWaiting?.friendId === f.id;
             const flag = f.country && COUNTRY_MAP[f.country] ? COUNTRY_MAP[f.country].flag + " " : "";
 
             return (
@@ -642,7 +644,26 @@ function FriendsCard({
                 </span>
                 {/* Challenge buttons */}
                 {isWaiting ? (
-                  <span style={{ fontSize: 10, color: "var(--text3)", fontWeight: 600, whiteSpace: "nowrap" }}>Waiting...</span>
+                  <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                    <span style={{ fontSize: 10, color: "var(--text3)", fontWeight: 600, whiteSpace: "nowrap" }}>Waiting...</span>
+                    <button
+                      onClick={onCancelChallenge}
+                      style={{
+                        background:   "transparent",
+                        color:        "var(--text3)",
+                        border:       "1px solid var(--border)",
+                        borderRadius: 4,
+                        padding:      "0.2rem 0.45rem",
+                        fontSize:     10,
+                        fontFamily:   "monospace",
+                        fontWeight:   700,
+                        cursor:       "pointer",
+                        whiteSpace:   "nowrap",
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
                 ) : (
                   <div style={{ display: "flex", gap: 4 }}>
                     <button
@@ -1181,7 +1202,7 @@ function PageInner() {
   const [friends, setFriends]                   = useState<Friend[]>([]);
   const [friendCode, setFriendCode]             = useState<string | null>(null);
   const [pendingChallenge, setPendingChallenge] = useState<IncomingChallenge | null>(null);
-  const [challengeWaiting, setChallengeWaiting] = useState<string | null>(null); // friendId while waiting
+  const [challengeWaiting, setChallengeWaiting] = useState<{ friendId: string; challengeId: string } | null>(null);
   const [friendToast, setFriendToast]           = useState<string | null>(null);
   const dashboardSocketRef = useRef<Socket | null>(null);
 
@@ -1383,7 +1404,7 @@ function PageInner() {
       { toUserId: friendId, mode },
       (res: { challengeId?: string; error?: string }) => {
         if (res.challengeId) {
-          setChallengeWaiting(friendId);
+          setChallengeWaiting({ friendId, challengeId: res.challengeId });
         }
       },
     );
@@ -1394,6 +1415,13 @@ function PageInner() {
     if (!socket?.connected || !pendingChallenge) return;
     socket.emit("challenge.accept", { challengeId: pendingChallenge.challengeId });
     supabase.from("pending_challenges").delete().eq("id", pendingChallenge.challengeId);
+  }
+
+  function handleCancelChallenge() {
+    const socket = dashboardSocketRef.current;
+    if (!challengeWaiting) return;
+    if (socket?.connected) socket.emit("challenge.cancel", { challengeId: challengeWaiting.challengeId });
+    setChallengeWaiting(null);
   }
 
   function handleDeclineChallenge() {
@@ -1684,6 +1712,7 @@ function PageInner() {
               pendingChallenge={pendingChallenge}
               onAcceptChallenge={handleAcceptChallenge}
               onDeclineChallenge={handleDeclineChallenge}
+              onCancelChallenge={handleCancelChallenge}
               challengeWaiting={challengeWaiting}
             />
           </div>


### PR DESCRIPTION
  Backend (backend/src/index.ts)
  - New challenge.cancel handler: validates the requester is the original challenger, cancels the timer, deletes from DB, and emits challenge.expired to the target via their user    
  room.             
                                                                                                                                                                                      
  Frontend (web/app/page.tsx)                                                                                                                                                       
  - challengeWaiting state changed from string | null to { friendId, challengeId } | null so the challengeId is available for cancellation.                                           
  - handleCancelChallenge: emits challenge.cancel with the challengeId and clears local state.
  - FriendsCard gets a new onCancelChallenge prop; the "Waiting..." label is now accompanied by a Cancel button that calls it.   