### PR TITLE
users reworked

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -2,7 +2,7 @@
   "name": "riverrank-backend",
   "version": "1.0.0",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "node --env-file=.env node_modules/.bin/tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "db:generate": "prisma generate",

--- a/backend/src/bot/registry.ts
+++ b/backend/src/bot/registry.ts
@@ -1,0 +1,183 @@
+import { supabaseAdmin } from "../db/supabaseAdmin";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type BotStyle = "tight" | "loose" | "balanced" | "aggro";
+
+export interface BotProfile {
+  id: string;
+  username: string;
+  elo: number;
+  style: BotStyle;
+  enabled: boolean;
+  rankedEnabled: boolean;
+  unrankedEnabled: boolean;
+  lastUsedAt: Date | null;
+  aggression: number;
+  bluffFrequency: number;
+  looseness: number;
+}
+
+// ── In-memory registry ──────────────────────────────────────────────────────
+
+const botIds = new Set<string>();
+let botsByElo: BotProfile[] = [];
+
+// Anti-repeat: userId → last 5 bot IDs faced (in-memory only for Phase 1)
+const recentBotOpponents = new Map<string, string[]>();
+
+const MAX_RECENT = 5;
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export async function loadBotRegistry(): Promise<void> {
+  const { data: profiles, error: profilesError } = await supabaseAdmin
+    .from("profiles")
+    .select("id, username, elo")
+    .eq("is_bot", true);
+
+  if (profilesError) throw profilesError;
+
+  const { data: configs, error: configsError } = await supabaseAdmin
+    .from("bot_config")
+    .select("*");
+
+  if (configsError) throw configsError;
+
+  const configMap = new Map(
+    (configs ?? []).map((c: any) => [c.id, c]),
+  );
+
+  botIds.clear();
+  const loaded: BotProfile[] = [];
+
+  for (const bot of profiles ?? []) {
+    botIds.add(bot.id);
+    const cfg = configMap.get(bot.id);
+    loaded.push({
+      id: bot.id,
+      username: bot.username ?? "Bot",
+      elo: bot.elo,
+      style: (cfg?.style as BotStyle) ?? "balanced",
+      enabled: cfg?.enabled ?? true,
+      rankedEnabled: cfg?.ranked_enabled ?? true,
+      unrankedEnabled: cfg?.unranked_enabled ?? true,
+      lastUsedAt: cfg?.last_used_at ? new Date(cfg.last_used_at) : null,
+      aggression: cfg?.aggression ?? 0.5,
+      bluffFrequency: cfg?.bluff_frequency ?? 0.1,
+      looseness: cfg?.looseness ?? 0.5,
+    });
+  }
+
+  // Sort by Elo ascending for matching
+  loaded.sort((a, b) => a.elo - b.elo);
+  botsByElo = loaded;
+
+  console.log(`[bot-registry] loaded ${botsByElo.length} bots`);
+}
+
+export function isBot(userId: string): boolean {
+  return botIds.has(userId);
+}
+
+export function getBotProfile(userId: string): BotProfile | null {
+  return botsByElo.find((b) => b.id === userId) ?? null;
+}
+
+/**
+ * Find a bot whose Elo is within ±200 of the target, excluding recently
+ * faced bots. Prefers bots closest in Elo, with tie-breaking on least
+ * recently used.
+ */
+export function findBotByElo(
+  targetElo: number,
+  userId: string,
+  mode: "ranked" | "unranked" | "bullet",
+): BotProfile | null {
+  const recent = recentBotOpponents.get(userId) ?? [];
+  const recentSet = new Set(recent);
+  const isRanked = mode === "ranked";
+
+  // Filter candidates
+  const candidates = botsByElo.filter((b) => {
+    if (!b.enabled) return false;
+    if (recentSet.has(b.id)) return false;
+    if (isRanked && !b.rankedEnabled) return false;
+    if (!isRanked && !b.unrankedEnabled) return false;
+    // Elo range guard: low-tier bots excluded for high-Elo players
+    if (b.elo < 950 && targetElo > 1400) return false;
+    // Within ±200
+    if (Math.abs(b.elo - targetElo) > 200) return false;
+    return true;
+  });
+
+  if (candidates.length === 0) {
+    // Relax: try any enabled bot in range, ignoring recent
+    const relaxed = botsByElo.filter((b) => {
+      if (!b.enabled) return false;
+      if (isRanked && !b.rankedEnabled) return false;
+      if (!isRanked && !b.unrankedEnabled) return false;
+      if (b.elo < 950 && targetElo > 1400) return false;
+      if (Math.abs(b.elo - targetElo) > 200) return false;
+      return true;
+    });
+    if (relaxed.length === 0) return null;
+    // Pick closest Elo
+    relaxed.sort((a, b) => Math.abs(a.elo - targetElo) - Math.abs(b.elo - targetElo));
+    return relaxed[0];
+  }
+
+  // Sort by Elo proximity, then by least recently used
+  candidates.sort((a, b) => {
+    const eloDiff = Math.abs(a.elo - targetElo) - Math.abs(b.elo - targetElo);
+    if (eloDiff !== 0) return eloDiff;
+    const aTime = a.lastUsedAt?.getTime() ?? 0;
+    const bTime = b.lastUsedAt?.getTime() ?? 0;
+    return aTime - bTime; // prefer least recently used
+  });
+
+  return candidates[0];
+}
+
+/**
+ * Record that a user just played against a bot (for anti-repeat tracking).
+ */
+export function recordBotOpponent(userId: string, botId: string): void {
+  let recent = recentBotOpponents.get(userId);
+  if (!recent) {
+    recent = [];
+    recentBotOpponents.set(userId, recent);
+  }
+  recent.push(botId);
+  if (recent.length > MAX_RECENT) recent.shift();
+}
+
+/**
+ * Update a bot's Elo in the in-memory registry after a match.
+ * The authoritative Elo lives in the DB (updated by end_match RPC);
+ * this keeps the registry cache in sync.
+ */
+export function updateBotElo(botId: string, newElo: number): void {
+  const bot = botsByElo.find((b) => b.id === botId);
+  if (!bot) return;
+  bot.elo = newElo;
+  // Re-sort
+  botsByElo.sort((a, b) => a.elo - b.elo);
+}
+
+/**
+ * Mark a bot as recently used (updates in-memory + fires DB update).
+ */
+export function markBotUsed(botId: string): void {
+  const bot = botsByElo.find((b) => b.id === botId);
+  if (bot) bot.lastUsedAt = new Date();
+
+  // Fire-and-forget DB update
+  supabaseAdmin
+    .from("bot_config")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("id", botId)
+    .then(({ error }) => {
+      if (error) console.error("[bot-registry] failed to update lastUsedAt:", error);
+    });
+}

--- a/backend/src/bot/seed.ts
+++ b/backend/src/bot/seed.ts
@@ -1,0 +1,498 @@
+/**
+ * Bot Seed Script
+ *
+ * Creates 50 persistent bot accounts for RiverRank.
+ *
+ * Design notes:
+ * - Bots are created as real Supabase auth users so the existing
+ *   profiles/auth foreign key integrity remains intact.
+ * - Bots are never meant to log in.
+ * - Script is idempotent:
+ *   - deterministic bot emails
+ *   - safe to re-run
+ *   - updates profile + bot_config for existing bots
+ *
+ * Usage:
+ *   npx tsx backend/src/bot/seed.ts
+ */
+
+import { createClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+}
+
+const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+type BotStyle = "tight" | "loose" | "balanced" | "aggro";
+type BotTier = "low" | "mid" | "high" | "elite";
+
+interface BotDef {
+  slug: string;
+  username: string;
+  elo: number;
+  style: BotStyle;
+  aggression: number;
+  bluffFrequency: number;
+  looseness: number;
+  country: string;
+  wins: number;
+  losses: number;
+}
+
+interface BotTemplate {
+  slug: string;
+  username: string;
+  style: BotStyle;
+}
+
+const COUNTRIES = [
+  "US",
+  "CA",
+  "BR",
+  "JP",
+  "KR",
+  "SE",
+  "CH",
+  "IN",
+  "MX",
+  "PH",
+  "NL",
+  "NO",
+  "DE",
+  "FR",
+  "AU",
+] as const;
+
+const STYLE_PARAMS: Record<
+  BotStyle,
+  { aggression: number; bluffFrequency: number; looseness: number }
+> = {
+  tight: {
+    aggression: 0.30,
+    bluffFrequency: 0.05,
+    looseness: 0.20,
+  },
+  loose: {
+    aggression: 0.40,
+    bluffFrequency: 0.12,
+    looseness: 0.70,
+  },
+  balanced: {
+    aggression: 0.50,
+    bluffFrequency: 0.10,
+    looseness: 0.45,
+  },
+  aggro: {
+    aggression: 0.80,
+    bluffFrequency: 0.20,
+    looseness: 0.40,
+  },
+};
+
+const lowBots: BotTemplate[] = [
+  { slug: "mike88", username: "mike88", style: "loose" },
+  { slug: "jaylen7", username: "jaylen7", style: "balanced" },
+  { slug: "coldfront", username: "coldfront", style: "loose" },
+  { slug: "sarah-h", username: "sarah_h", style: "balanced" },
+  { slug: "ember41", username: "ember41", style: "loose" },
+  { slug: "tommyd", username: "tommyD", style: "balanced" },
+  { slug: "riverrat42", username: "RiverRat42", style: "loose" },
+  { slug: "kaylah", username: "kaylah", style: "balanced" },
+  { slug: "duskfall", username: "duskfall", style: "loose" },
+  { slug: "brianw", username: "brianW", style: "balanced" },
+];
+
+const midBots: BotTemplate[] = [
+  { slug: "nina-k", username: "nina_k", style: "tight" },
+  { slug: "devr", username: "devR", style: "balanced" },
+  { slug: "marcus21", username: "marcus21", style: "loose" },
+  { slug: "bluemesa", username: "BlueMesa", style: "balanced" },
+  { slug: "northline", username: "northline", style: "tight" },
+  { slug: "elena99", username: "elena99", style: "aggro" },
+  { slug: "vortex", username: "vortex_", style: "loose" },
+  { slug: "frostbyte", username: "frostbyte", style: "balanced" },
+  { slug: "ridgeline", username: "ridgeline", style: "tight" },
+  { slug: "snapcall99", username: "SnapCall99", style: "aggro" },
+  { slug: "alex-j", username: "alex_j", style: "balanced" },
+  { slug: "ironside", username: "ironside", style: "tight" },
+  { slug: "sablewing", username: "sablewing", style: "loose" },
+  { slug: "cassidy", username: "cassidy", style: "balanced" },
+  { slug: "valuetown", username: "ValueTown", style: "aggro" },
+  { slug: "maxp", username: "maxp", style: "balanced" },
+  { slug: "stillwater", username: "stillwater", style: "tight" },
+  { slug: "jordanlee", username: "jordanlee", style: "loose" },
+  { slug: "redfern", username: "redfern", style: "balanced" },
+  { slug: "harper42", username: "harper42", style: "aggro" },
+];
+
+const highBots: BotTemplate[] = [
+  { slug: "summit", username: "summit", style: "tight" },
+  { slug: "zara-m", username: "zara_m", style: "balanced" },
+  { slug: "foldequity", username: "FoldEquity", style: "tight" },
+  { slug: "crux", username: "crux", style: "aggro" },
+  { slug: "oakhurst", username: "oakhurst", style: "balanced" },
+  { slug: "nitnate", username: "NitNate", style: "tight" },
+  { slug: "dani77", username: "dani77", style: "balanced" },
+  { slug: "stoneridge", username: "stoneridge", style: "tight" },
+  { slug: "kira-v", username: "kira_v", style: "aggro" },
+  { slug: "quartzline", username: "quartzline", style: "balanced" },
+  { slug: "ryanc", username: "ryanc", style: "tight" },
+  { slug: "ashgrove", username: "ashgrove", style: "balanced" },
+  { slug: "celeste", username: "celeste", style: "tight" },
+  { slug: "tundra", username: "tundra", style: "aggro" },
+  { slug: "liwei", username: "liwei", style: "balanced" },
+];
+
+const eliteBots: BotTemplate[] = [
+  { slug: "glacier", username: "glacier", style: "tight" },
+  { slug: "spectra", username: "spectra", style: "balanced" },
+  { slug: "axiom", username: "axiom", style: "tight" },
+  { slug: "neonveil", username: "neonveil", style: "balanced" },
+  { slug: "zenith", username: "zenith", style: "tight" },
+];
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function pickCountry(index: number): string {
+  return COUNTRIES[index % COUNTRIES.length];
+}
+
+function hashString(input: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash >>> 0);
+}
+
+function seededFraction(seed: string): number {
+  return hashString(seed) / 4294967295;
+}
+
+function seededRange(seed: string, min: number, max: number): number {
+  return min + seededFraction(seed) * (max - min);
+}
+
+function seededInt(seed: string, min: number, max: number): number {
+  return Math.floor(seededRange(seed, min, max + 1));
+}
+
+function genWinLoss(slug: string, tier: BotTier): {
+  wins: number;
+  losses: number;
+} {
+  const gamesBase =
+    tier === "elite" ? 120 : tier === "high" ? 80 : tier === "mid" ? 60 : 50;
+
+  const gamesExtra =
+    tier === "elite"
+      ? seededInt(`${slug}:games`, 20, 90)
+      : seededInt(`${slug}:games`, 10, 80);
+
+  const gamesPlayed = gamesBase + gamesExtra;
+
+  let minRate = 0.35;
+  let maxRate = 0.45;
+
+  if (tier === "mid") {
+    minRate = 0.45;
+    maxRate = 0.52;
+  } else if (tier === "high") {
+    minRate = 0.50;
+    maxRate = 0.58;
+  } else if (tier === "elite") {
+    minRate = 0.55;
+    maxRate = 0.65;
+  }
+
+  const winRate = seededRange(`${slug}:winrate`, minRate, maxRate);
+  const wins = Math.round(gamesPlayed * winRate);
+  const losses = gamesPlayed - wins;
+
+  return { wins, losses };
+}
+
+function assertUniqueBots(bots: BotDef[]): void {
+  const slugs = new Set<string>();
+  const usernames = new Set<string>();
+
+  for (const bot of bots) {
+    if (slugs.has(bot.slug)) {
+      throw new Error(`Duplicate bot slug found: ${bot.slug}`);
+    }
+
+    const usernameKey = bot.username.toLowerCase();
+    if (usernames.has(usernameKey)) {
+      throw new Error(`Duplicate bot username found: ${bot.username}`);
+    }
+
+    slugs.add(bot.slug);
+    usernames.add(usernameKey);
+  }
+}
+
+function buildBots(): BotDef[] {
+  const bots: BotDef[] = [];
+
+  for (let i = 0; i < lowBots.length; i++) {
+    const bot = lowBots[i];
+    const elo = 700 + Math.round((i / (lowBots.length - 1)) * 250);
+    const stats = genWinLoss(bot.slug, "low");
+    const params = STYLE_PARAMS[bot.style];
+
+    bots.push({
+      slug: bot.slug,
+      username: bot.username,
+      elo,
+      style: bot.style,
+      aggression: params.aggression,
+      bluffFrequency: params.bluffFrequency,
+      looseness: params.looseness,
+      country: pickCountry(i),
+      ...stats,
+    });
+  }
+
+  for (let i = 0; i < midBots.length; i++) {
+    const bot = midBots[i];
+    const elo = 1000 + Math.round((i / (midBots.length - 1)) * 300);
+    const stats = genWinLoss(bot.slug, "mid");
+    const params = STYLE_PARAMS[bot.style];
+
+    bots.push({
+      slug: bot.slug,
+      username: bot.username,
+      elo,
+      style: bot.style,
+      aggression: params.aggression,
+      bluffFrequency: params.bluffFrequency,
+      looseness: params.looseness,
+      country: pickCountry(i + 10),
+      ...stats,
+    });
+  }
+
+  for (let i = 0; i < highBots.length; i++) {
+    const bot = highBots[i];
+    const elo = 1350 + Math.round((i / (highBots.length - 1)) * 250);
+    const stats = genWinLoss(bot.slug, "high");
+    const params = STYLE_PARAMS[bot.style];
+
+    bots.push({
+      slug: bot.slug,
+      username: bot.username,
+      elo,
+      style: bot.style,
+      aggression: params.aggression,
+      bluffFrequency: params.bluffFrequency,
+      looseness: params.looseness,
+      country: pickCountry(i + 30),
+      ...stats,
+    });
+  }
+
+  for (let i = 0; i < eliteBots.length; i++) {
+    const bot = eliteBots[i];
+    const elo = 1650 + Math.round((i / (eliteBots.length - 1)) * 250);
+    const stats = genWinLoss(bot.slug, "elite");
+    const params = STYLE_PARAMS[bot.style];
+
+    bots.push({
+      slug: bot.slug,
+      username: bot.username,
+      elo,
+      style: bot.style,
+      aggression: clamp01(params.aggression + 0.15),
+      bluffFrequency: clamp01(params.bluffFrequency + 0.05),
+      looseness: params.looseness,
+      country: pickCountry(i + 45),
+      ...stats,
+    });
+  }
+
+  assertUniqueBots(bots);
+  return bots;
+}
+
+const BOTS = buildBots();
+
+async function listAllAuthUsersByEmail(): Promise<
+  Map<string, { id: string; email: string }>
+> {
+  const usersByEmail = new Map<string, { id: string; email: string }>();
+
+  let page = 1;
+  const perPage = 200;
+
+  while (true) {
+    const { data, error } = await supabaseAdmin.auth.admin.listUsers({
+      page,
+      perPage,
+    });
+
+    if (error) {
+      throw new Error(`Failed listing auth users: ${error.message}`);
+    }
+
+    const users = data?.users ?? [];
+
+    for (const user of users) {
+      if (user.email) {
+        usersByEmail.set(user.email, {
+          id: user.id,
+          email: user.email,
+        });
+      }
+    }
+
+    if (users.length < perPage) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return usersByEmail;
+}
+
+async function createBotAuthUser(email: string, slug: string): Promise<string> {
+  const passwordSeed = seededInt(`${slug}:password`, 100000, 999999999);
+
+  const { data, error } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    email_confirm: true,
+    password: `bot-${slug}-${passwordSeed}`,
+    user_metadata: {
+      is_bot: true,
+      bot_slug: slug,
+      source: "bot_seed_script",
+    },
+    app_metadata: {
+      is_bot: true,
+      role: "bot",
+    },
+  });
+
+  if (error || !data.user) {
+    throw new Error(
+      `Failed creating auth user for ${slug}: ${error?.message ?? "unknown error"}`,
+    );
+  }
+
+  return data.user.id;
+}
+
+async function updateProfile(bot: BotDef, userId: string): Promise<void> {
+  const { error } = await supabaseAdmin
+    .from("profiles")
+    .update({
+      username: bot.username,
+      elo: bot.elo,
+      wins: bot.wins,
+      losses: bot.losses,
+      is_bot: true,
+      country: bot.country,
+    })
+    .eq("id", userId);
+
+  if (error) {
+    throw new Error(
+      `Failed updating profile for ${bot.username}: ${error.message}`,
+    );
+  }
+}
+
+async function upsertBotConfig(bot: BotDef, userId: string): Promise<void> {
+  const { error } = await supabaseAdmin.from("bot_config").upsert({
+    id: userId,
+    style: bot.style,
+    aggression: bot.aggression,
+    bluff_frequency: bot.bluffFrequency,
+    looseness: bot.looseness,
+    avatar_seed: bot.slug,
+    enabled: true,
+    show_on_leaderboard: true,
+    ranked_enabled: true,
+    unranked_enabled: true,
+  });
+
+  if (error) {
+    throw new Error(
+      `Failed upserting bot_config for ${bot.username}: ${error.message}`,
+    );
+  }
+}
+
+async function seed(): Promise<void> {
+  console.log(`Seeding ${BOTS.length} bots...`);
+
+  const existingUsersByEmail = await listAllAuthUsersByEmail();
+
+  let createdCount = 0;
+  let existingCount = 0;
+  let updatedCount = 0;
+  const failures: Array<{ bot: string; error: string }> = [];
+
+  for (const bot of BOTS) {
+    const email = `bot-${bot.slug}@riverrank.internal`;
+
+    try {
+      let userId: string;
+      const existing = existingUsersByEmail.get(email);
+
+      if (existing) {
+        userId = existing.id;
+        existingCount += 1;
+        console.log(`  [exists]   ${bot.username} (${userId.slice(0, 8)})`);
+      } else {
+        userId = await createBotAuthUser(email, bot.slug);
+        existingUsersByEmail.set(email, { id: userId, email });
+        createdCount += 1;
+        console.log(`  [created]  ${bot.username} (${userId.slice(0, 8)})`);
+      }
+
+      await updateProfile(bot, userId);
+      await upsertBotConfig(bot, userId);
+
+      updatedCount += 1;
+      console.log(
+        `  [upserted] ${bot.username} elo=${bot.elo} w=${bot.wins} l=${bot.losses} country=${bot.country}`,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unknown error";
+      failures.push({ bot: bot.username, error: message });
+      console.error(`  [failed]   ${bot.username}: ${message}`);
+    }
+  }
+
+  console.log("");
+  console.log("Seed summary");
+  console.log("------------");
+  console.log(`Bots defined:   ${BOTS.length}`);
+  console.log(`Auth created:   ${createdCount}`);
+  console.log(`Auth existing:  ${existingCount}`);
+  console.log(`Profiles/config upserted: ${updatedCount}`);
+  console.log(`Failures:       ${failures.length}`);
+
+  if (failures.length > 0) {
+    console.log("");
+    console.log("Failures:");
+    for (const failure of failures) {
+      console.log(`- ${failure.bot}: ${failure.error}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log("");
+    console.log("Done.");
+  }
+}
+
+void seed();

--- a/backend/src/bot/strategy.ts
+++ b/backend/src/bot/strategy.ts
@@ -1,33 +1,16 @@
 import type { Card, LegalActions } from "../engine/types";
 import { bestHand } from "../engine/handEvaluator";
+import type { BotProfile } from "./registry";
 
-// ── Difficulty ────────────────────────────────────────────────────────────────
+// ── Hand strength (6-bucket) ────────────────────────────────────────────────
 
-export type BotDifficulty = "easy" | "medium" | "hard";
-
-interface BotConfig {
-  strongRaiseFreq:  number; // probability to raise when holding a strong hand
-  bluffFreq:        number; // probability to bluff-raise with a weak hand
-  potOddsThreshold: number; // fold medium hand if pot odds exceed this
-  callLooseness:    number; // fraction of marginal hands that call vs fold
-}
-
-const BOT_CONFIGS: Record<BotDifficulty, BotConfig> = {
-  easy:   { strongRaiseFreq: 0.15, bluffFreq: 0.00, potOddsThreshold: 0.45, callLooseness: 0.85 },
-  medium: { strongRaiseFreq: 0.35, bluffFreq: 0.08, potOddsThreshold: 0.30, callLooseness: 0.55 },
-  hard:   { strongRaiseFreq: 0.55, bluffFreq: 0.18, potOddsThreshold: 0.20, callLooseness: 0.35 },
-};
-
-// ── Hand strength ─────────────────────────────────────────────────────────────
-
-type HandStrength = "STRONG" | "MEDIUM" | "WEAK" | "TRASH";
+export type HandStrength = "PREMIUM" | "STRONG" | "GOOD" | "MEDIUM" | "WEAK" | "TRASH";
 
 const RANK_VAL: Record<string, number> = {
   "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7,
   "8": 8, "9": 9, "T": 10, "J": 11, "Q": 12, "K": 13, "A": 14,
 };
 
-/** Classify preflop hand strength using a 4-bucket lookup. */
 function preflopStrength(c1: Card, c2: Card): HandStrength {
   let r1 = RANK_VAL[c1[0]], r2 = RANK_VAL[c2[0]];
   const suited = c1[1] === c2[1];
@@ -35,124 +18,367 @@ function preflopStrength(c1: Card, c2: Card): HandStrength {
 
   // Pocket pairs
   if (r1 === r2) {
-    if (r1 >= 10) return "STRONG"; // TT+
-    if (r1 >= 7)  return "MEDIUM"; // 77-99
-    if (r1 >= 5)  return "WEAK";   // 55-66
-    return "TRASH";                // 22-44
+    if (r1 >= 12) return "PREMIUM"; // QQ+
+    if (r1 >= 10) return "STRONG";  // TT-JJ
+    if (r1 >= 7)  return "GOOD";    // 77-99
+    if (r1 >= 4)  return "MEDIUM";  // 44-66
+    return "WEAK";                  // 22-33
   }
 
-  if (r1 === 14) { // Ace-high
-    if (r2 >= 13)          return "STRONG";                   // AK
-    if (r2 >= 11)          return "MEDIUM";                   // AQ, AJ
-    if (r2 >= 10)          return suited ? "MEDIUM" : "WEAK"; // AT
-    if (r2 >= 6 && suited) return "WEAK";                     // A6s-A9s
+  // Ace-high
+  if (r1 === 14) {
+    if (r2 >= 13 && suited) return "PREMIUM";  // AKs
+    if (r2 >= 13) return "STRONG";              // AKo
+    if (r2 >= 12 && suited) return "STRONG";    // AQs
+    if (r2 >= 12) return "GOOD";                // AQo
+    if (r2 >= 11) return "GOOD";                // AJ
+    if (r2 >= 10) return "MEDIUM";              // AT
+    if (suited)   return "WEAK";                // Axs
     return "TRASH";
   }
 
-  if (r1 === 13) { // King-high
-    if (r2 >= 12)          return "MEDIUM";                   // KQ
-    if (r2 >= 11)          return suited ? "MEDIUM" : "WEAK"; // KJ
-    if (r2 >= 10 && suited) return "WEAK";                    // KTs
+  // King-high
+  if (r1 === 13) {
+    if (r2 >= 12) return "GOOD";                        // KQ
+    if (r2 >= 11) return suited ? "GOOD" : "MEDIUM";    // KJ
+    if (r2 >= 10 && suited) return "MEDIUM";             // KTs
     return "TRASH";
   }
 
-  if (r1 === 12) { // Queen-high
-    if (r2 >= 11)          return suited ? "MEDIUM" : "WEAK"; // QJ
-    if (r2 >= 10 && suited) return "WEAK";                    // QTs
+  // Queen-high
+  if (r1 === 12) {
+    if (r2 >= 11) return suited ? "MEDIUM" : "WEAK";    // QJ
+    if (r2 >= 10 && suited) return "WEAK";               // QTs
     return "TRASH";
   }
 
-  if (r1 === 11 && r2 === 10) return suited ? "WEAK" : "TRASH"; // JT
+  // JT
+  if (r1 === 11 && r2 === 10) return suited ? "MEDIUM" : "WEAK";
 
-  // Suited connectors and one-gappers
+  // Suited connectors / one-gappers
   if (suited && r1 >= 6 && r1 - r2 <= 2) return "WEAK";
 
   return "TRASH";
 }
 
-const POSTFLOP_STRENGTH: Record<string, HandStrength> = {
-  STRAIGHT_FLUSH:  "STRONG",
-  FOUR_OF_A_KIND:  "STRONG",
-  FULL_HOUSE:      "STRONG",
-  FLUSH:           "STRONG",
-  STRAIGHT:        "STRONG",
-  THREE_OF_A_KIND: "MEDIUM",
-  TWO_PAIR:        "MEDIUM",
-  ONE_PAIR:        "WEAK",
-  HIGH_CARD:       "TRASH",
-};
+function postflopStrength(holeCards: [Card, Card], board: Card[]): HandStrength {
+  const rank = bestHand(holeCards, board);
+  const cat = rank.category;
+
+  if (cat === "STRAIGHT_FLUSH" || cat === "FOUR_OF_A_KIND" || cat === "FULL_HOUSE") return "PREMIUM";
+  if (cat === "FLUSH" || cat === "STRAIGHT") return "STRONG";
+  if (cat === "THREE_OF_A_KIND") return "GOOD";
+  if (cat === "TWO_PAIR") {
+    // Strong two pair (top pair involved) = GOOD, otherwise MEDIUM
+    const boardRanks = board.map((c) => RANK_VAL[c[0]]).sort((a, b) => b - a);
+    const holeRanks = holeCards.map((c) => RANK_VAL[c[0]]).sort((a, b) => b - a);
+    if (holeRanks[0] >= boardRanks[0]) return "GOOD";
+    return "MEDIUM";
+  }
+  if (cat === "ONE_PAIR") {
+    // Determine pair type via kicker analysis
+    const boardRanks = board.map((c) => RANK_VAL[c[0]]).sort((a, b) => b - a);
+    const holeRanks = holeCards.map((c) => RANK_VAL[c[0]]).sort((a, b) => b - a);
+
+    // Check if hole card makes top pair
+    const topBoard = boardRanks[0];
+    if (holeRanks[0] === topBoard || holeRanks[1] === topBoard) {
+      // Top pair — kicker quality matters
+      const kicker = holeRanks[0] === topBoard ? holeRanks[1] : holeRanks[0];
+      if (kicker >= 11) return "GOOD";    // Top pair + good kicker (J+)
+      return "MEDIUM";                     // Top pair + weak kicker
+    }
+
+    // Middle or bottom pair
+    if (holeRanks.some((r) => r >= boardRanks[1] && boardRanks.includes(r))) return "WEAK";
+    return "WEAK";
+  }
+
+  return "TRASH"; // HIGH_CARD
+}
 
 function evaluateStrength(holeCards: [Card, Card], board: Card[], street: string): HandStrength {
   if (street === "PREFLOP") return preflopStrength(holeCards[0], holeCards[1]);
-  const rank = bestHand(holeCards, board);
-  return POSTFLOP_STRENGTH[rank.category] ?? "TRASH";
+  return postflopStrength(holeCards, board);
 }
 
-// ── Decision function ─────────────────────────────────────────────────────────
+// ── Board texture ───────────────────────────────────────────────────────────
+
+type BoardTexture = "dry" | "draw_heavy" | "paired";
+
+function classifyBoard(board: Card[]): BoardTexture {
+  if (board.length < 3) return "dry";
+
+  const ranks = board.map((c) => RANK_VAL[c[0]]);
+  const suits = board.map((c) => c[1]);
+
+  // Paired board
+  const uniqueRanks = new Set(ranks);
+  if (uniqueRanks.size < ranks.length) return "paired";
+
+  // Flush draw potential (3+ of same suit)
+  const suitCounts = new Map<string, number>();
+  for (const s of suits) suitCounts.set(s, (suitCounts.get(s) ?? 0) + 1);
+  const maxSuitCount = Math.max(...suitCounts.values());
+  if (maxSuitCount >= 3) return "draw_heavy";
+
+  // Straight draw potential (3+ cards within 4-rank span)
+  const sorted = [...ranks].sort((a, b) => a - b);
+  for (let i = 0; i < sorted.length - 2; i++) {
+    if (sorted[i + 2] - sorted[i] <= 4) return "draw_heavy";
+  }
+
+  return "dry";
+}
+
+// ── Bot game context ────────────────────────────────────────────────────────
+
+export interface BotGameContext {
+  holeCards: [Card, Card];
+  board: Card[];
+  street: string;
+  legal: LegalActions;
+  pot: number;
+  bigBlind: number;
+  heroStack: number;
+  villainStack: number;
+  wasLastAggressor: boolean;
+}
+
+// ── Weighted action selection ───────────────────────────────────────────────
+
+interface ActionWeights {
+  FOLD: number;
+  CHECK: number;
+  CALL: number;
+  RAISE: number;
+}
+
+function sampleAction(weights: ActionWeights): string {
+  const entries = Object.entries(weights).filter(([, w]) => w > 0);
+  const total = entries.reduce((sum, [, w]) => sum + w, 0);
+  if (total === 0) return "FOLD";
+
+  let r = Math.random() * total;
+  for (const [action, w] of entries) {
+    r -= w;
+    if (r <= 0) return action;
+  }
+  return entries[entries.length - 1][0];
+}
+
+// ── Decision engine ─────────────────────────────────────────────────────────
 
 export function decideBotAction(
-  holeCards:  [Card, Card],
-  board:      Card[],
-  street:     string,
-  legal:      LegalActions,
-  pot:        number,
-  bigBlind:   number,
-  difficulty: BotDifficulty,
+  ctx: BotGameContext,
+  profile: BotProfile,
 ): { action: string; amount?: number } {
-  const cfg      = BOT_CONFIGS[difficulty];
-  const strength = evaluateStrength(holeCards, board, street);
+  const strength = evaluateStrength(ctx.holeCards, ctx.board, ctx.street);
+  const boardTex = classifyBoard(ctx.board);
+  const callAmount = ctx.legal.callAmount ?? 0;
+  const potOdds = callAmount > 0 ? callAmount / (ctx.pot + callAmount) : 0;
 
-  const callAmount = legal.callAmount ?? 0;
-  const potOdds    = callAmount > 0 ? callAmount / (pot + callAmount) : 0;
+  // Stack depth categories
+  const effectiveStack = Math.min(ctx.heroStack, ctx.villainStack);
+  const bb = ctx.bigBlind || 20;
+  const stackDepth = effectiveStack / bb;
+  const isShallow = stackDepth < 15;
+  const isDeep = stackDepth > 40;
 
-  const tryRaise = (): { action: string; amount: number } | null => {
-    if (!legal.minRaiseTo || !legal.maxRaiseTo) return null;
-    // Target ~75% pot raise; clamp to [minRaiseTo, maxRaiseTo]
-    const target = Math.round(legal.minRaiseTo + pot * 0.75);
-    const cap    = Math.min(Math.max(target, legal.minRaiseTo), legal.maxRaiseTo);
-    const amount = Math.round(legal.minRaiseTo + Math.random() * (cap - legal.minRaiseTo));
-    return { action: "RAISE_TO", amount };
-  };
+  // Profile-derived adjustments
+  const { aggression, bluffFrequency, looseness } = profile;
 
-  // Free to check — consider raising with strong hands, otherwise check
-  if (legal.canCheck) {
-    if (strength === "STRONG" && Math.random() < cfg.strongRaiseFreq) {
-      const r = tryRaise();
-      if (r) return r;
+  // Compute action weights based on strength + context
+  const weights: ActionWeights = { FOLD: 0, CHECK: 0, CALL: 0, RAISE: 0 };
+
+  if (ctx.legal.canCheck) {
+    // Free to act — no bet to call
+    switch (strength) {
+      case "PREMIUM":
+        weights.CHECK = 0.15;
+        weights.RAISE = 0.85 * aggression * 2;
+        break;
+      case "STRONG":
+        weights.CHECK = 0.3;
+        weights.RAISE = 0.7 * aggression * 1.5;
+        break;
+      case "GOOD":
+        weights.CHECK = 0.5;
+        weights.RAISE = 0.5 * aggression;
+        break;
+      case "MEDIUM":
+        weights.CHECK = 0.7;
+        weights.RAISE = 0.3 * aggression;
+        break;
+      case "WEAK":
+        weights.CHECK = 0.85;
+        weights.RAISE = bluffFrequency * 0.5; // small bluff chance
+        break;
+      case "TRASH":
+        weights.CHECK = 0.9;
+        weights.RAISE = bluffFrequency * 0.3;
+        break;
     }
-    return { action: "CHECK" };
+
+    // Board texture adjustments
+    if (boardTex === "draw_heavy" && (strength === "GOOD" || strength === "STRONG")) {
+      weights.RAISE *= 1.3; // bet to protect on draw-heavy boards
+    }
+    if (boardTex === "dry" && strength === "PREMIUM") {
+      weights.CHECK *= 1.5; // slow-play more on dry boards
+    }
+  } else {
+    // Facing a bet
+    switch (strength) {
+      case "PREMIUM":
+        weights.CALL = 0.2;
+        weights.RAISE = 0.8 * aggression * 2;
+        break;
+      case "STRONG":
+        weights.CALL = 0.5;
+        weights.RAISE = 0.5 * aggression * 1.5;
+        break;
+      case "GOOD":
+        weights.CALL = 0.6;
+        weights.RAISE = 0.25 * aggression;
+        weights.FOLD = potOdds > 0.4 ? 0.15 : 0;
+        break;
+      case "MEDIUM":
+        if (potOdds < 0.3) {
+          weights.CALL = 0.6 * looseness * 2;
+          weights.FOLD = 0.4 * (1 - looseness);
+        } else {
+          weights.CALL = 0.3 * looseness * 2;
+          weights.FOLD = 0.7 * (1 - looseness);
+        }
+        weights.RAISE = bluffFrequency * 0.2;
+        break;
+      case "WEAK":
+        if (potOdds < 0.15) {
+          weights.CALL = 0.3 * looseness;
+          weights.FOLD = 0.7;
+        } else {
+          weights.CALL = 0.1 * looseness;
+          weights.FOLD = 0.8;
+        }
+        weights.RAISE = bluffFrequency * 0.4; // bluff raise
+        break;
+      case "TRASH":
+        weights.FOLD = 0.85;
+        weights.CALL = 0.05 * looseness;
+        weights.RAISE = bluffFrequency * 0.5; // bluff raise
+        break;
+    }
+
+    // Shallow stack: reduce folding with decent hands, increase shove tendency
+    if (isShallow && (strength === "GOOD" || strength === "STRONG" || strength === "PREMIUM")) {
+      weights.RAISE *= 1.5;
+      weights.FOLD *= 0.3;
+    }
+
+    // Previous aggressor check: if villain has been betting and we have a marginal hand, fold more
+    if (ctx.wasLastAggressor && (strength === "WEAK" || strength === "TRASH")) {
+      weights.FOLD *= 1.3;
+    }
+
+    // Deep stacks: play tighter with marginal hands
+    if (isDeep && (strength === "MEDIUM" || strength === "WEAK")) {
+      weights.FOLD *= 1.2;
+      weights.CALL *= 0.8;
+    }
   }
 
-  // Facing a bet
-  if (strength === "STRONG") {
-    if (Math.random() < cfg.strongRaiseFreq) {
-      const r = tryRaise();
-      if (r) return r;
+  // ── All-in defense: facing a huge bet, tighten up with decent hands ──
+  if (!ctx.legal.canCheck && callAmount > 0) {
+    const betToStackRatio = callAmount / (ctx.heroStack + callAmount);
+    const isAllIn = callAmount >= ctx.heroStack; // calling costs entire stack
+
+    if (isAllIn || betToStackRatio > 0.5) {
+      // Facing all-in or pot-committing bet: strong+ hands should never fold
+      if (strength === "PREMIUM" || strength === "STRONG") {
+        weights.FOLD = 0;
+        weights.CALL = Math.max(weights.CALL, 1);
+      } else if (strength === "GOOD") {
+        weights.FOLD *= 0.3;
+        weights.CALL = Math.max(weights.CALL, 0.5);
+      } else if (strength === "MEDIUM") {
+        // Medium hands: consider pot odds more carefully against all-ins
+        weights.FOLD *= 0.7;
+        weights.CALL = Math.max(weights.CALL, 0.3 * looseness);
+      }
+      // Weak/trash: folding to all-ins is fine (unless it means match loss — handled below)
     }
-    return { action: "CALL" };
   }
 
-  if (strength === "MEDIUM") {
-    if (potOdds < cfg.potOddsThreshold) return { action: "CALL" };
-    // Bad pot odds: fold with probability (1 - callLooseness)
-    if (Math.random() < 1 - cfg.callLooseness) return { action: "FOLD" };
-    return { action: "CALL" };
+  // ── Never fold into match loss ──
+  // If folding would leave the bot with 0 chips (losing the match), always call instead
+  if (weights.FOLD > 0 && ctx.heroStack <= callAmount) {
+    weights.FOLD = 0;
+    weights.CALL = Math.max(weights.CALL, 1);
   }
 
-  // WEAK: call with very favorable pot odds, otherwise fold (or bluff)
-  if (strength === "WEAK") {
-    if (Math.random() < cfg.bluffFreq) {
-      const r = tryRaise();
-      if (r) return r;
-    }
-    if (potOdds > 0 && potOdds < cfg.potOddsThreshold * 0.5) return { action: "CALL" };
+  // Remove illegal actions
+  if (!ctx.legal.canCheck) weights.CHECK = 0;
+  if (!ctx.legal.canCall) weights.CALL = 0;
+  if (!ctx.legal.canFold) weights.FOLD = 0;
+  if (!ctx.legal.minRaiseTo || !ctx.legal.maxRaiseTo) weights.RAISE = 0;
+
+  // Ensure at least one action has weight
+  const totalWeight = weights.FOLD + weights.CHECK + weights.CALL + weights.RAISE;
+  if (totalWeight === 0) {
+    if (ctx.legal.canCheck) return { action: "CHECK" };
+    if (ctx.legal.canCall) return { action: "CALL" };
     return { action: "FOLD" };
   }
 
-  // TRASH: bluff or fold
-  if (Math.random() < cfg.bluffFreq) {
-    const r = tryRaise();
-    if (r) return r;
+  const action = sampleAction(weights);
+
+  if (action === "RAISE" && ctx.legal.minRaiseTo && ctx.legal.maxRaiseTo) {
+    const raiseAmount = computeRaiseAmount(
+      ctx, strength, aggression, isShallow,
+    );
+    return { action: "RAISE_TO", amount: raiseAmount };
   }
-  return { action: "FOLD" };
+
+  return { action };
+}
+
+// ── Raise sizing ────────────────────────────────────────────────────────────
+
+function computeRaiseAmount(
+  ctx: BotGameContext,
+  strength: HandStrength,
+  aggression: number,
+  isShallow: boolean,
+): number {
+  const min = ctx.legal.minRaiseTo!;
+  const max = ctx.legal.maxRaiseTo!;
+
+  // Shallow stacks: tend to shove
+  if (isShallow && (strength === "PREMIUM" || strength === "STRONG" || strength === "GOOD")) {
+    return max; // all-in
+  }
+
+  // Size based on hand strength and aggression
+  let potFraction: number;
+  switch (strength) {
+    case "PREMIUM":
+      potFraction = 0.7 + aggression * 0.3; // 70-100% pot
+      break;
+    case "STRONG":
+      potFraction = 0.6 + aggression * 0.2; // 60-80% pot
+      break;
+    case "GOOD":
+      potFraction = 0.5 + aggression * 0.15; // 50-65% pot
+      break;
+    default:
+      // Bluffs: vary more to be unpredictable
+      potFraction = 0.4 + Math.random() * 0.3; // 40-70% pot
+      break;
+  }
+
+  const target = Math.round(min + ctx.pot * potFraction);
+  // Add small randomness (±10%)
+  const jitter = Math.round(target * (0.9 + Math.random() * 0.2));
+  return Math.min(Math.max(jitter, min), max);
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,7 +16,14 @@ import { newDeck, shuffle } from "./engine/deck";
 import { getLegalActions, validateAction, ActionError } from "./engine/betting";
 import { showdownWinner, bestHand } from "./engine/handEvaluator";
 import { decideBotAction } from "./bot/strategy";
-import type { BotDifficulty } from "./bot/strategy";
+import type { BotGameContext } from "./bot/strategy";
+
+// Legacy type — kept for backwards compatibility during transition
+type BotDifficulty = "easy" | "medium" | "hard";
+import {
+  isBot, getBotProfile, findBotByElo, updateBotElo,
+  markBotUsed, recordBotOpponent, loadBotRegistry,
+} from "./bot/registry";
 import { prisma } from "./db";
 import { supabaseAdmin } from "./db/supabaseAdmin";
 
@@ -31,8 +38,13 @@ interface User {
 
 // ── Bot constants ─────────────────────────────────────────────────────────────
 
+// Legacy fallback (kept as safety net — remove after bot ladder stabilizes)
 const BOT_ID               = "00000000-0000-0000-0000-000000000000";
 const BOT_QUEUE_TIMEOUT_MS = 20_000;
+
+// Organic bot timing: random delay before a bot "joins the queue"
+const BOT_JOIN_MIN_MS = 7_000;
+const BOT_JOIN_MAX_MS = 12_000;
 
 // ── Turn timer ────────────────────────────────────────────────────────────────
 
@@ -159,22 +171,36 @@ app.get("/leaderboard", async (_req, res) => {
 
 // ── Bot helpers ───────────────────────────────────────────────────────────────
 
+// Legacy fallback safety net. Remove after bot ladder stabilizes.
 function makeBotUser(): User {
   return { userId: BOT_ID, username: "RiverBot", socketId: "", elo: 1200 };
-}
-
-function getBotDifficulty(mode: Mode, elo: number): BotDifficulty {
-  if (mode === "unranked") return "easy";
-  // Bullet uses ELO-based scaling like ranked
-  if (elo < 1100) return "easy";
-  if (elo <= 1300) return "medium";
-  return "hard";
 }
 
 function clearQueueTimer(userId: string): void {
   const t = queueTimers.get(userId);
   if (t) { clearTimeout(t); queueTimers.delete(userId); }
+  // Also clear organic bot timer if one exists
+  const organicKey = `organic:${userId}`;
+  const ot = botTimers.get(organicKey);
+  if (ot) { clearTimeout(ot); botTimers.delete(organicKey); }
   queuedPlayers.delete(userId);
+}
+
+function removeUserFromQueues(userId: string, socketId?: string): Mode[] {
+  clearQueueTimer(userId);
+
+  const removedFrom: Mode[] = [];
+  for (const mode of ["ranked", "unranked", "bullet"] as Mode[]) {
+    const idx = queues[mode].findIndex((queuedUser) => (
+      queuedUser.userId === userId && (!socketId || queuedUser.socketId === socketId)
+    ));
+    if (idx === -1) continue;
+
+    queues[mode].splice(idx, 1);
+    removedFrom.push(mode);
+  }
+
+  return removedFrom;
 }
 
 // ── State serialization ───────────────────────────────────────────────────────
@@ -269,7 +295,7 @@ function emitGameState(state: InternalGameState): void {
   const pub = toPublicState(state);
 
   for (const player of state.players) {
-    if (player.id === BOT_ID) continue; // bot has no socket
+    if (isBot(player.id)) continue; // bot has no socket
     const socketId = state.socketIds[player.id];
     const socket   = io.sockets.sockets.get(socketId);
     if (!socket) continue;
@@ -312,30 +338,48 @@ function emitGameState(state: InternalGameState): void {
   // Emit spectator state to spectate room
   emitSpectatorState(state);
 
-  // Schedule bot turn if it's the bot's turn to act
-  if (state.toActId === BOT_ID && state.street !== "SHOWDOWN" && !state.ended) {
+  // Schedule bot turn if it's a bot's turn to act
+  const botProfile = getBotProfile(state.toActId);
+  if (botProfile && state.street !== "SHOWDOWN" && !state.ended) {
     const existing = botTimers.get(state.matchId);
     if (existing) clearTimeout(existing);
 
+    const botId = state.toActId;
     const delay = 1000 + Math.random() * 1500; // 1000–2500 ms
     const timer = setTimeout(() => {
       botTimers.delete(state.matchId);
-      if (state.toActId !== BOT_ID || state.street === "SHOWDOWN" || state.ended) return;
+      if (state.toActId !== botId || state.street === "SHOWDOWN" || state.ended) return;
 
-      const legal      = getLegalActions(state, BOT_ID);
-      const holeCards  = state.holeCards[BOT_ID];
+      const legal = getLegalActions(state, botId);
+      const holeCards = state.holeCards[botId];
       if (!holeCards) return;
 
-      const difficulty = botDifficulties.get(state.matchId) ?? "easy";
-      const { action, amount } = decideBotAction(
-        holeCards, state.board, state.street,
-        legal, state.pot, state.bigBlind, difficulty,
-      );
+      const opponent = state.players.find((p) => p.id !== botId)!;
+      const hero = state.players.find((p) => p.id === botId)!;
+
+      // Determine if bot was last aggressor (simplified: check last log entry)
+      const lastAgg = state.log.length > 0 &&
+        state.log[state.log.length - 1].action === "raise" &&
+        state.log[state.log.length - 1].playerId === botId;
+
+      const ctx: BotGameContext = {
+        holeCards,
+        board: state.board,
+        street: state.street,
+        legal,
+        pot: state.pot,
+        bigBlind: state.bigBlind,
+        heroStack: hero.stack,
+        villainStack: opponent.stack,
+        wasLastAggressor: lastAgg,
+      };
+
+      const { action, amount } = decideBotAction(ctx, botProfile);
 
       console.log(
-        `[bot] RiverBot acting — action=${action}${amount !== undefined ? ` amount=${amount}` : ""}`,
+        `[bot] ${botProfile.username} acting — action=${action}${amount !== undefined ? ` amount=${amount}` : ""}`,
       );
-      applyAction(state, BOT_ID, action, amount);
+      applyAction(state, botId, action, amount);
     }, delay);
 
     botTimers.set(state.matchId, timer);
@@ -698,23 +742,10 @@ function forfeitMatch(
 
   const matchId    = state.matchId;
   const ranked     = state.mode === "ranked";
-  const isBotMatch = state.players.some((p) => p.id === BOT_ID);
+  const isBotMatch = state.players.some((p) => isBot(p.id));
 
   // Notify spectators
   io.to(`spectate:${matchId}`).emit("spectate.ended", { winnerId, winnerUsername });
-
-  if (isBotMatch) {
-    io.to(`match:${matchId}`).emit("match.ended", {
-      matchId,
-      winnerId,
-      winnerUsername,
-      ranked: false,
-      ratingDelta: null,
-      reason,
-    });
-    console.log(`[forfeit] bot match ended — reason=${reason} winner=${winnerUsername}`);
-    return;
-  }
 
   (async () => {
     let ratingDelta: Record<string, number> | null = null;
@@ -726,6 +757,16 @@ function forfeitMatch(
       }
       if (ranked) {
         ratingDelta = { [state.players[0].id]: result.p1Delta, [state.players[1].id]: result.p2Delta };
+      }
+      // Update bot Elo in registry if bot was involved
+      if (isBotMatch) {
+        for (const p of state.players) {
+          if (isBot(p.id)) {
+            const newElo = p.id === state.players[0].id
+              ? result.p1EloAfter : result.p2EloAfter;
+            updateBotElo(p.id, newElo);
+          }
+        }
       }
     } catch (err) {
       console.error("[db] recordMatchEnd (forfeit) failed:", err);
@@ -816,39 +857,43 @@ function endHand(state: InternalGameState, winnerIndex: 0 | 1, reason: "FOLD" | 
     const ranked         = state.mode === "ranked";
     const p1             = state.players[0];
     const p2             = state.players[1];
-    const isBotMatch     = p1.id === BOT_ID || p2.id === BOT_ID;
+    const isBotMatch     = isBot(p1.id) || isBot(p2.id) || p1.id === BOT_ID || p2.id === BOT_ID;
 
     // Async: call RPC (DB guard), then emit match.ended with authoritative deltas.
     (async () => {
       let ratingDelta: Record<string, number> | null = null;
       try {
-        if (!isBotMatch) {
-          const result = await recordMatchEnd(state, winnerId);
+        const result = await recordMatchEnd(state, winnerId);
 
-          if (result === null) {
-            // DB guard fired — already recorded, skip emit to avoid duplicate.
-            console.warn(`[match.ended] duplicate RPC call for ${matchId.slice(0, 8)}, skipping`);
-            return;
-          }
+        if (result === null) {
+          console.warn(`[match.ended] duplicate RPC call for ${matchId.slice(0, 8)}, skipping`);
+          return;
+        }
 
-          if (ranked) {
-            ratingDelta = { [p1.id]: result.p1Delta, [p2.id]: result.p2Delta };
-            console.log(
-              `[match.ended] winnerId=${winnerId.slice(0, 8)} ranked=true` +
-              ` ${p1.username}: ${result.p1EloBefore}→${result.p1EloAfter}` +
-              ` (${result.p1Delta >= 0 ? "+" : ""}${result.p1Delta})` +
-              ` ${p2.username}: ${result.p2EloBefore}→${result.p2EloAfter}` +
-              ` (${result.p2Delta >= 0 ? "+" : ""}${result.p2Delta})`,
-            );
-          } else {
-            console.log(
-              `[match.ended] winnerId=${winnerId.slice(0, 8)} ranked=false winner=${winnerUsername}`,
-            );
-          }
+        if (ranked) {
+          ratingDelta = { [p1.id]: result.p1Delta, [p2.id]: result.p2Delta };
+          console.log(
+            `[match.ended] winnerId=${winnerId.slice(0, 8)} ranked=true` +
+            ` ${p1.username}: ${result.p1EloBefore}→${result.p1EloAfter}` +
+            ` (${result.p1Delta >= 0 ? "+" : ""}${result.p1Delta})` +
+            ` ${p2.username}: ${result.p2EloBefore}→${result.p2EloAfter}` +
+            ` (${result.p2Delta >= 0 ? "+" : ""}${result.p2Delta})`,
+          );
         } else {
           console.log(
-            `[match.ended] bot match winnerId=${winnerId.slice(0, 8)} winner=${winnerUsername}`,
+            `[match.ended] winnerId=${winnerId.slice(0, 8)} ranked=false winner=${winnerUsername}`,
           );
+        }
+
+        // Update bot Elo in registry cache
+        if (isBotMatch) {
+          for (const p of [p1, p2]) {
+            if (isBot(p.id)) {
+              const newElo = p.id === state.players[0].id
+                ? result.p1EloAfter : result.p2EloAfter;
+              updateBotElo(p.id, newElo);
+            }
+          }
         }
       } catch (err) {
         console.error("[db] recordMatchEnd failed:", err);
@@ -996,8 +1041,8 @@ async function createMatch(
   }
 
   matches.set(matchId, state);
-  if (p1.userId !== BOT_ID) activeMatches.set(p1.userId, matchId);
-  if (p2.userId !== BOT_ID) activeMatches.set(p2.userId, matchId);
+  if (!isBot(p1.userId)) activeMatches.set(p1.userId, matchId);
+  if (!isBot(p2.userId)) activeMatches.set(p2.userId, matchId);
   if (botDifficulty) botDifficulties.set(matchId, botDifficulty);
 
   const room = `match:${matchId}`;
@@ -1258,7 +1303,7 @@ setInterval(() => {
     // Skip matches with no active turn, at showdown, or with timer cleared/guarded
     if (
       !state.toActId          ||
-      state.toActId === BOT_ID   || // bot acts via its own timer
+      isBot(state.toActId)      || // bot acts via its own timer
       state.street === "SHOWDOWN" ||
       state.turnDeadlineMs === 0      ||
       state.turnDeadlineMs === Infinity ||
@@ -1277,7 +1322,7 @@ setInterval(() => {
 
     // Track consecutive timeouts for non-bot players
     state.consecutiveTimeouts[playerId] = (state.consecutiveTimeouts[playerId] ?? 0) + 1;
-    const isBotMatch = state.players.some((p) => p.id === BOT_ID);
+    const isBotMatch = state.players.some((p) => isBot(p.id));
     if (state.consecutiveTimeouts[playerId] >= 3 && !isBotMatch) {
       console.log(`[timeout] player=${playerName} hit 3 consecutive timeouts — auto-forfeit`);
       forfeitMatch(state, playerId, "TIMEOUT");
@@ -1322,11 +1367,18 @@ io.on("connection", (socket: Socket) => {
           throw e;
         }
       }
+      // Fetch authoritative elo from Supabase profiles (source of truth)
+      const { data: profile } = await supabaseAdmin
+        .from("profiles")
+        .select("elo")
+        .eq("id", verifiedId)
+        .single();
+
       const user: User = {
         userId:   verifiedId,
-        username: dbUser.username,
+        username: dbUser.username ?? trimmed,
         socketId: socket.id,
-        elo:      dbUser.elo,
+        elo:      profile?.elo ?? dbUser.elo,
       };
       // ── Multi-tab presence: allow multiple sockets per user ──
       const existingSocketId = userSockets.get(verifiedId);
@@ -1385,6 +1437,7 @@ io.on("connection", (socket: Socket) => {
     if (activeMatches.has(user.userId)) return; // prevent re-queuing during active match
     if (playerTournament.has(user.userId)) return; // prevent queuing while in tournament
     if (queuedPlayers.has(user.userId)) return;    // atomic guard: prevent race from multiple sockets
+    clearQueueTimer(user.userId);                  // reset any stale fallback timer before re-queueing
     const queueMode: Mode = mode === "unranked" ? "unranked" : mode === "bullet" ? "bullet" : "ranked";
     const q = queues[queueMode];
     if (q.some((u) => u.userId === user.userId)) return;
@@ -1399,34 +1452,58 @@ io.on("connection", (socket: Socket) => {
         console.error("[match] createMatch error:", err),
       );
     } else {
-      // No opponent yet — pair with bot after 20 seconds
-      const timer = setTimeout(() => {
+      // No opponent yet — organic bot timer (7-12s), with legacy 20s fallback
+      const organicDelay = BOT_JOIN_MIN_MS + Math.random() * (BOT_JOIN_MAX_MS - BOT_JOIN_MIN_MS);
+      const organicTimer = setTimeout(() => {
+        const idx = q.findIndex((u) => u.userId === user.userId);
+        if (idx === -1) return; // already matched or left
+
+        const bot = findBotByElo(user.elo, user.userId, queueMode);
+        if (!bot) {
+          console.log(`[queue:${queueMode}] ${user.username} — no bot found, waiting for legacy fallback`);
+          return; // let legacy 20s timer handle it
+        }
+
+        // Found a bot — remove from queue and create match
+        q.splice(idx, 1);
+        clearQueueTimer(user.userId);
+        const botUser: User = { userId: bot.id, username: bot.username, socketId: "", elo: bot.elo };
+        markBotUsed(bot.id);
+        recordBotOpponent(user.userId, bot.id);
+        console.log(`[queue:${queueMode}] ${user.username} matched with bot ${bot.username} (elo=${bot.elo})`);
+        createMatch(user, botUser, queueMode).catch((err) =>
+          console.error("[match] bot createMatch error:", err),
+        );
+      }, organicDelay);
+
+      // Legacy fallback safety net. Remove after bot ladder stabilizes.
+      const legacyTimer = setTimeout(() => {
         queueTimers.delete(user.userId);
         queuedPlayers.delete(user.userId);
         const idx = q.findIndex((u) => u.userId === user.userId);
         if (idx === -1) return; // already matched or left
         q.splice(idx, 1);
-        const difficulty = getBotDifficulty(queueMode, user.elo);
-        console.log(`[queue:${queueMode}] ${user.username} timed out — matching with bot (${difficulty})`);
+        console.log(`[queue:${queueMode}] ${user.username} — legacy 20s fallback triggered`);
         const botMode = queueMode === "bullet" ? "bullet" : "unranked";
-        createMatch(user, makeBotUser(), botMode, difficulty).catch((err) =>
-          console.error("[match] bot createMatch error:", err),
+        createMatch(user, makeBotUser(), botMode).catch((err) =>
+          console.error("[match] legacy bot createMatch error:", err),
         );
       }, BOT_QUEUE_TIMEOUT_MS);
-      queueTimers.set(user.userId, timer);
+
+      // Store legacy timer so clearQueueTimer can cancel it
+      queueTimers.set(user.userId, legacyTimer);
+      // Also track organic timer so we can clear it
+      // We piggyback on botTimers since it's not match-specific here — use a unique key
+      const organicKey = `organic:${user.userId}`;
+      botTimers.set(organicKey, organicTimer);
     }
   });
 
   socket.on("queue.leave", () => {
     const user = users.get(socket.id);
     if (!user) return;
-    clearQueueTimer(user.userId);
-    for (const m of ["ranked", "unranked", "bullet"] as Mode[]) {
-      const idx = queues[m].findIndex((u) => u.userId === user.userId);
-      if (idx !== -1) {
-        queues[m].splice(idx, 1);
-        console.log(`[queue:${m}] ${user.username} left — size: ${queues[m].length}`);
-      }
+    for (const mode of removeUserFromQueues(user.userId)) {
+      console.log(`[queue:${mode}] ${user.username} left — size: ${queues[mode].length}`);
     }
   });
 
@@ -1496,9 +1573,9 @@ io.on("connection", (socket: Socket) => {
 
     state.readyForNextHand[user.userId] = true;
 
-    const isBotMatch = state.players.some((p) => p.id === BOT_ID);
+    const isBotMatch = state.players.some((p) => isBot(p.id));
     const allReady = isBotMatch
-      ? state.players.some((p) => p.id !== BOT_ID && state.readyForNextHand[p.id])
+      ? state.players.some((p) => !isBot(p.id) && state.readyForNextHand[p.id])
       : state.players.every((p) => state.readyForNextHand[p.id]);
 
     if (allReady) {
@@ -2154,11 +2231,7 @@ io.on("connection", (socket: Socket) => {
 
       // Only clean up queue/challenges/match when ALL sockets are gone
       if (!stillOnline) {
-        clearQueueTimer(user.userId);
-        for (const m of ["ranked", "unranked", "bullet"] as Mode[]) {
-          const idx = queues[m].findIndex((u) => u.userId === user.userId);
-          if (idx !== -1) queues[m].splice(idx, 1);
-        }
+        removeUserFromQueues(user.userId);
 
         // Clean up pending challenges where this user is the challenger
         for (const [cid, challenge] of pendingChallenges) {
@@ -2183,7 +2256,7 @@ io.on("connection", (socket: Socket) => {
         if (matchId) {
           const state = matches.get(matchId);
           if (state && !state.ended) {
-            const isBotMatch = state.players.some((p) => p.id === BOT_ID);
+            const isBotMatch = state.players.some((p) => isBot(p.id));
             if (isBotMatch) {
               forfeitMatch(state, user.userId, "DISCONNECT");
             } else {
@@ -2205,6 +2278,10 @@ io.on("connection", (socket: Socket) => {
         }
 
         queuedPlayers.delete(user.userId);
+      } else {
+        for (const mode of removeUserFromQueues(user.userId, socket.id)) {
+          console.log(`[queue:${mode}] ${user.username} disconnected while queued — size: ${queues[mode].length}`);
+        }
       }
 
       users.delete(socket.id);
@@ -2219,4 +2296,11 @@ io.on("connection", (socket: Socket) => {
 
 // ── Start ─────────────────────────────────────────────────────────────────────
 
-httpServer.listen(4000, () => console.log("Backend running on http://localhost:4000"));
+loadBotRegistry()
+  .then(() => {
+    httpServer.listen(4000, () => console.log("Backend running on http://localhost:4000"));
+  })
+  .catch((err) => {
+    console.error("[bot-registry] failed to load, starting without bots:", err);
+    httpServer.listen(4000, () => console.log("Backend running on http://localhost:4000 (no bot registry)"));
+  });

--- a/supabase/migrations/013_bot_ladder.sql
+++ b/supabase/migrations/013_bot_ladder.sql
@@ -1,0 +1,54 @@
+-- Add is_bot flag to profiles
+ALTER TABLE public.profiles
+ADD COLUMN IF NOT EXISTS is_bot boolean NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_profiles_is_bot
+ON public.profiles (is_bot);
+
+-- Bot config table: behavioral and availability settings for bot accounts
+CREATE TABLE IF NOT EXISTS public.bot_config (
+  id                   uuid PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
+
+  -- IDENTITY (supplements profiles.username, profiles.country)
+  avatar_seed          text,
+
+  -- AVAILABILITY
+  enabled              boolean NOT NULL DEFAULT true,
+  show_on_leaderboard  boolean NOT NULL DEFAULT true,
+  ranked_enabled       boolean NOT NULL DEFAULT true,
+  unranked_enabled     boolean NOT NULL DEFAULT true,
+
+  -- BEHAVIOR (Phase 1 primary knobs)
+  style                text NOT NULL DEFAULT 'balanced'
+                         CHECK (style IN ('tight', 'loose', 'balanced', 'aggro')),
+  aggression           float NOT NULL DEFAULT 0.5
+                         CHECK (aggression >= 0 AND aggression <= 1),
+  bluff_frequency      float NOT NULL DEFAULT 0.1
+                         CHECK (bluff_frequency >= 0 AND bluff_frequency <= 1),
+  looseness            float NOT NULL DEFAULT 0.5
+                         CHECK (looseness >= 0 AND looseness <= 1),
+
+  -- BEHAVIOR (Phase 2+ knobs)
+  preflop_tightness    float
+                         CHECK (preflop_tightness IS NULL OR (preflop_tightness >= 0 AND preflop_tightness <= 1)),
+  pot_odds_awareness   float
+                         CHECK (pot_odds_awareness IS NULL OR (pot_odds_awareness >= 0 AND pot_odds_awareness <= 1)),
+
+  -- TRACKING
+  last_used_at         timestamptz,
+  created_at           timestamptz NOT NULL DEFAULT now()
+);
+-- Update RLS policies to include is_bot in the guard for profile setup
+-- (is_bot should not be changeable by regular users)
+DROP POLICY IF EXISTS "profiles: user can set up profile" ON public.profiles;
+CREATE POLICY "profiles: user can set up profile"
+  ON public.profiles FOR UPDATE
+  USING  (auth.uid() = id AND username IS NULL)
+  WITH CHECK (
+    auth.uid() = id
+    AND elo             IS NOT DISTINCT FROM (SELECT elo             FROM public.profiles WHERE id = auth.uid())
+    AND wins            IS NOT DISTINCT FROM (SELECT wins            FROM public.profiles WHERE id = auth.uid())
+    AND losses          IS NOT DISTINCT FROM (SELECT losses          FROM public.profiles WHERE id = auth.uid())
+    AND friend_code     IS NOT DISTINCT FROM (SELECT friend_code     FROM public.profiles WHERE id = auth.uid())
+    AND is_bot          IS NOT DISTINCT FROM (SELECT is_bot          FROM public.profiles WHERE id = auth.uid())
+  );

--- a/web/app/game/page.tsx
+++ b/web/app/game/page.tsx
@@ -226,6 +226,9 @@ function GameView() {
   }
 
   function backToLobby() {
+    if (status === "in queue…") {
+      socketRef.current?.emit("queue.leave");
+    }
     socketRef.current?.disconnect();
     if (isTournamentMatch) {
       router.push(`/tournament/${tournamentId}`);
@@ -510,12 +513,9 @@ function GameView() {
             </span>
             {status === "in queue…" && queueStartMs && (() => {
               const elapsed  = Math.floor((Date.now() - queueStartMs) / 1000);
-              const remaining = Math.max(0, 20 - elapsed);
               return (
                 <span style={{ color: "var(--text3)", fontSize: 11, fontFamily: "monospace" }}>
-                  {remaining > 0
-                    ? `Bot joins in ${remaining}s`
-                    : "Joining with bot…"}
+                  Searching for opponent… {elapsed}s
                 </span>
               );
             })()}


### PR DESCRIPTION
## 🚀 Persistent Bot Ladder (Ranked + Unranked)

### Summary
Introduces a persistent bot system to simulate real players, improving matchmaking availability and enabling continuous ranked play even at low user volume.

Bots behave like real users, participate in Elo-based matches, and populate the leaderboard.

---

### Key Changes

- **Bot Accounts**
  - ~50 bots seeded via Supabase Admin API
  - Unique usernames, countries, Elo tiers
  - Marked with `profiles.is_bot = true`

- **Bot Config System**
  - Added `bot_config` table
  - Stores behavior (style, aggression, bluff freq, looseness)
  - Includes availability + leaderboard visibility flags

- **Matchmaking**
  - Bots act as real opponents when no human is available
  - Supports both ranked (Elo) and unranked
  - Keeps existing 20s fallback bots (temporary)

- **Leaderboard**
  - Bots populate ladder across Elo ranges
  - Prevents empty leaderboard UX

---

### Schema Changes

```sql
-- profiles
is_bot boolean NOT NULL DEFAULT false;

-- new table
bot_config (behavior + config)